### PR TITLE
:tada: New backtesting module

### DIFF
--- a/athena/optimize/__init__.py
+++ b/athena/optimize/__init__.py
@@ -1,3 +1,4 @@
 from athena.optimize.strategy import Strategy
+from athena.optimize.orders import Position, Trade
 
-__all__ = ["Strategy"]
+__all__ = ["Strategy", "Position", "Trade"]

--- a/athena/optimize/__init__.py
+++ b/athena/optimize/__init__.py
@@ -1,4 +1,4 @@
 from athena.optimize.strategy import Strategy
-from athena.optimize.orders import Position, Trade
+from athena.optimize.orders import Position, Trade, Portfolio
 
-__all__ = ["Strategy", "Position", "Trade"]
+__all__ = ["Strategy", "Position", "Trade", "Portfolio"]

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -1,6 +1,8 @@
 from athena.optimize import Strategy, Trade
 import pandas as pd
 
+from athena.types import Signal
+
 
 def get_trades_from_strategy_and_fluctuations(
     strategy: Strategy, fluctuations: pd.DataFrame
@@ -14,9 +16,19 @@ def get_trades_from_strategy_and_fluctuations(
     Returns:
         market movement as a list of trades
     """
-    # TODO: iterate over fluctuations
-    #       1/ get entry signal
-    #       2/ when buy, open a position at close price (= beginning of next candle)
-    #       3/ check exit conditions (strategy sell, tp or sl)
-    #       4/ close position & create new trade
-    return []
+    trades = []
+    for open_time, signal in strategy.get_signals(fluctuations):
+        match signal:
+            case Signal.WAIT:
+                continue
+            case Signal.BUY:
+                # TODO : check if an open position already exists
+                #        if not, open a position at close price
+                continue
+            case Signal.SELL:
+                # TODO : check if an open position already exists
+                #        if yes, close it at close price and create a new trade
+                continue
+        # TODO : check if a position needs to be closed (price reaches tp, sl, limit date)
+        #        if yes, close it at price and create a new trade
+    return trades

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -14,4 +14,9 @@ def get_trades_from_strategy_and_fluctuations(
     Returns:
         market movement as a list of trades
     """
+    # TODO: iterate over fluctuations
+    #       1/ get entry signal
+    #       2/ when buy, open a position at close price (= beginning of next candle)
+    #       3/ check exit conditions (strategy sell, tp or sl)
+    #       4/ close position & create new trade
     return []

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -1,0 +1,8 @@
+from athena.optimize import Strategy
+import pandas as pd
+
+
+def get_trades_from_fluctuations_and_strategy(
+    fluctuations: pd.DataFrame, strategy: Strategy
+) -> list:
+    pass

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -23,6 +23,8 @@ def get_trades_from_strategy_and_fluctuations(
     open_position = None
     portfolio = Portfolio.model_validate({"assets": {currency: 100}})
 
+    period = Period(timeframe=fluctuations["period"].values[0])
+
     trades = []
     for open_time, signal in strategy.get_signals(fluctuations):
         df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
@@ -47,8 +49,6 @@ def get_trades_from_strategy_and_fluctuations(
         match signal:
             case Signal.BUY:
                 if open_position is None:
-                    df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
-                    period = Period(timeframe=df_row["period"].values[0])
                     open_position = Position.from_money_to_invest(
                         strategy_name=strategy.name,
                         coin=traded_coin,
@@ -69,8 +69,6 @@ def get_trades_from_strategy_and_fluctuations(
                     )
             case Signal.SELL:
                 if open_position is not None:
-                    df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
-                    period = Period(timeframe=df_row["period"].values[0])
                     new_trade = Trade.from_position(
                         position=open_position,
                         close_date=pd.to_datetime(

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -8,7 +8,7 @@ from athena.types import Signal
 
 def get_trades_from_strategy_and_fluctuations(
     strategy: Strategy, fluctuations: pd.DataFrame
-) -> tuple[list[Trade], Position | None]:
+) -> tuple[list[Trade], Position | None, Portfolio]:
     """Compute the trades that a strategy would have made given fluctuations.
 
     Args:
@@ -41,10 +41,10 @@ def get_trades_from_strategy_and_fluctuations(
                         open_price=df_row["close"],
                         money_to_invest=portfolio.get_available(currency)
                         * strategy.position_size,
-                        stop_loss=df_row["close"] * strategy.stop_loss_pct
+                        stop_loss=df_row["close"] * (1 - strategy.stop_loss_pct)
                         if strategy.stop_loss_pct is not None
                         else None,
-                        take_profit=df_row["close"] * strategy.take_profit_pct
+                        take_profit=df_row["close"] * (1 + strategy.take_profit_pct)
                         if strategy.take_profit_pct is not None
                         else None,
                     )
@@ -68,4 +68,4 @@ def get_trades_from_strategy_and_fluctuations(
                 # TODO : check if a position needs to be closed (price reaches tp, sl, limit date)
                 #        if yes, close it at price and create a new trade
                 continue
-    return trades, open_position
+    return trades, open_position, portfolio

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -1,6 +1,7 @@
 from athena.optimize import Strategy, Trade, Portfolio, Position
-from athena.types import Coin
+from athena.types import Coin, Period
 import pandas as pd
+import datetime
 
 from athena.types import Signal
 
@@ -25,18 +26,18 @@ def get_trades_from_strategy_and_fluctuations(
     trades = []
     for open_time, signal in strategy.get_signals(fluctuations):
         match signal:
-            case Signal.WAIT:
-                continue
             case Signal.BUY:
-                df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
                 if open_position is None:
+                    df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
+                    period = Period(timeframe=df_row["period"].values[0])
                     open_position = Position.from_money_to_invest(
                         strategy_name=strategy.name,
                         coin=traded_coin,
                         currency=currency,
                         open_date=pd.to_datetime(
                             df_row["open_time"].values[0]
-                        ).to_pydatetime(),
+                        ).to_pydatetime()
+                        + datetime.timedelta(**{period.unit_full: period.value}),
                         open_price=df_row["close"],
                         money_to_invest=portfolio.get_available(currency)
                         * strategy.position_size,
@@ -49,9 +50,22 @@ def get_trades_from_strategy_and_fluctuations(
                     )
                 continue
             case Signal.SELL:
-                # TODO : check if an open position already exists
-                #        if yes, close it at close price and create a new trade
+                if open_position is not None:
+                    df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
+                    period = Period(timeframe=df_row["period"].values[0])
+                    new_trade = Trade.from_position(
+                        position=open_position,
+                        close_date=pd.to_datetime(
+                            df_row["open_time"].values[0]
+                        ).to_pydatetime()
+                        + datetime.timedelta(**{period.unit_full: period.value}),
+                        close_price=df_row["close"],
+                    )
+                    trades.append(new_trade)
+                    open_position = None
                 continue
-        # TODO : check if a position needs to be closed (price reaches tp, sl, limit date)
-        #        if yes, close it at price and create a new trade
+            case Signal.WAIT:
+                # TODO : check if a position needs to be closed (price reaches tp, sl, limit date)
+                #        if yes, close it at price and create a new trade
+                continue
     return trades, open_position

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -1,8 +1,17 @@
-from athena.optimize import Strategy
+from athena.optimize import Strategy, Trade
 import pandas as pd
 
 
-def get_trades_from_fluctuations_and_strategy(
-    fluctuations: pd.DataFrame, strategy: Strategy
-) -> list:
-    pass
+def get_trades_from_strategy_and_fluctuations(
+    strategy: Strategy, fluctuations: pd.DataFrame
+) -> list[Trade]:
+    """Compute the trades that a strategy would have made given fluctuations.
+
+    Args:
+        strategy: the strategy to get entry signals
+        fluctuations: financial data
+
+    Returns:
+        market movement as a list of trades
+    """
+    return []

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -25,6 +25,25 @@ def get_trades_from_strategy_and_fluctuations(
 
     trades = []
     for open_time, signal in strategy.get_signals(fluctuations):
+        df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
+
+        # check tp / sl exit signals
+        close_price, close_date = check_position_exit_signals(
+            position=open_position, row=df_row
+        )
+        if (
+            (close_price is not None)
+            & (close_date is not None)
+            & (open_position is not None)
+        ):
+            new_trade = Trade.from_position(
+                position=open_position,
+                close_date=close_date,
+                close_price=close_price,
+            )
+            trades.append(new_trade)
+            open_position = None
+
         match signal:
             case Signal.BUY:
                 if open_position is None:
@@ -48,7 +67,6 @@ def get_trades_from_strategy_and_fluctuations(
                         if strategy.take_profit_pct is not None
                         else None,
                     )
-                continue
             case Signal.SELL:
                 if open_position is not None:
                     df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
@@ -63,9 +81,65 @@ def get_trades_from_strategy_and_fluctuations(
                     )
                     trades.append(new_trade)
                     open_position = None
+            case _:  # is Signal.WAIT
                 continue
-            case Signal.WAIT:
-                # TODO : check if a position needs to be closed (price reaches tp, sl, limit date)
-                #        if yes, close it at price and create a new trade
-                continue
+
     return trades, open_position, portfolio
+
+
+def check_position_exit_signals(
+    position: Position | None, row: pd.Series
+) -> tuple[float | None, datetime.datetime | None]:
+    """Check if a candle reaches position's take profit or stop loss.
+
+    Args:
+        position: any open position
+        row: a market candle
+
+    Returns:
+        close_price: the sell price of the position or None if position remains open
+        close_date: the close date of the position or None if position remains open
+    """
+    if position is None:
+        return None, None
+
+    period = Period(timeframe=row["period"].values[0])
+    price_reach_tp = (
+        (position.take_profit < row["high"].item())
+        if position.take_profit is not None
+        else False
+    )
+    price_reach_sl = (
+        (position.stop_loss > row["low"].item())
+        if position.stop_loss is not None
+        else False
+    )
+
+    if (
+        price_reach_tp and price_reach_sl
+    ):  # candle is very wide, check which signal occurred first
+        if ("high_time" in row) and ("low_time" in row):
+            if row["high_time"] < row["low_time"]:  # price reached high before low
+                close_price = position.take_profit
+                close_date = pd.to_datetime(row["high_time"].values[0]).to_pydatetime()
+            else:  # price reached low before high
+                close_price = position.stop_loss
+                close_date = pd.to_datetime(row["low_time"].values[0]).to_pydatetime()
+        else:  # we don't have granularity, assume close price is close enough to real sell price
+            close_price = row["close"]
+            close_date = pd.to_datetime(
+                row["low_time"].values[0]
+            ).to_pydatetime() + datetime.timedelta(**{period.unit_full: period.value})
+    elif price_reach_tp:
+        time_column = "high_time" if "high_time" in row else "close_time"
+        close_price = position.take_profit
+        close_date = pd.to_datetime(row[time_column].values[0]).to_pydatetime()
+    elif price_reach_sl:
+        time_column = "low_time" if "high_time" in row else "close_time"
+        close_price = position.stop_loss
+        close_date = pd.to_datetime(row[time_column].values[0]).to_pydatetime()
+    else:  # we don't close the position
+        close_price = None
+        close_date = None
+
+    return close_price, close_date

--- a/athena/optimize/backtesting.py
+++ b/athena/optimize/backtesting.py
@@ -1,4 +1,5 @@
-from athena.optimize import Strategy, Trade
+from athena.optimize import Strategy, Trade, Portfolio, Position
+from athena.types import Coin
 import pandas as pd
 
 from athena.types import Signal
@@ -6,7 +7,7 @@ from athena.types import Signal
 
 def get_trades_from_strategy_and_fluctuations(
     strategy: Strategy, fluctuations: pd.DataFrame
-) -> list[Trade]:
+) -> tuple[list[Trade], Position | None]:
     """Compute the trades that a strategy would have made given fluctuations.
 
     Args:
@@ -16,14 +17,36 @@ def get_trades_from_strategy_and_fluctuations(
     Returns:
         market movement as a list of trades
     """
+    traded_coin = Coin.BTC
+    currency = Coin.USDT
+    open_position = None
+    portfolio = Portfolio.model_validate({"assets": {currency: 100}})
+
     trades = []
     for open_time, signal in strategy.get_signals(fluctuations):
         match signal:
             case Signal.WAIT:
                 continue
             case Signal.BUY:
-                # TODO : check if an open position already exists
-                #        if not, open a position at close price
+                df_row = fluctuations.loc[fluctuations["open_time"] == open_time]
+                if open_position is None:
+                    open_position = Position.from_money_to_invest(
+                        strategy_name=strategy.name,
+                        coin=traded_coin,
+                        currency=currency,
+                        open_date=pd.to_datetime(
+                            df_row["open_time"].values[0]
+                        ).to_pydatetime(),
+                        open_price=df_row["close"],
+                        money_to_invest=portfolio.get_available(currency)
+                        * strategy.position_size,
+                        stop_loss=df_row["close"] * strategy.stop_loss_pct
+                        if strategy.stop_loss_pct is not None
+                        else None,
+                        take_profit=df_row["close"] * strategy.take_profit_pct
+                        if strategy.take_profit_pct is not None
+                        else None,
+                    )
                 continue
             case Signal.SELL:
                 # TODO : check if an open position already exists
@@ -31,4 +54,4 @@ def get_trades_from_strategy_and_fluctuations(
                 continue
         # TODO : check if a position needs to be closed (price reaches tp, sl, limit date)
         #        if yes, close it at price and create a new trade
-    return trades
+    return trades, open_position

--- a/athena/optimize/orders.py
+++ b/athena/optimize/orders.py
@@ -17,6 +17,8 @@ class Position(BaseModel):
         open_date: the date when the position was opened, usually the open_date of a candle
         open_price: coin's price when the position was opened
         amount: coin's amount that have been bought
+        open_fees: cost of opening a new position, fees are taken before calculating coin amount
+        initial_investment: the initial amount of currency the trader invested
         stop_loss: stop your loss, close the position if the price reach this level
         take_profit: take your profit, close the position if the price reach this level
         side: weather the position is a long or a short
@@ -74,6 +76,11 @@ class Trade(Position):
         ...
         close_date: the date when a position was closed
         close_price: the closing price of the position
+        close_fees: fees from selling the position
+        total_fees: sum of open and close fees
+        total_profit: remaining money when we sell the position and remove fees
+        is_win: if we made money on this trade or not
+        trade_duration: position total lifetime
     """
 
     close_date: datetime.datetime

--- a/athena/optimize/orders.py
+++ b/athena/optimize/orders.py
@@ -1,6 +1,6 @@
 import datetime
 
-from athena.types import Side
+from athena.types import Side, Coin
 from pydantic import BaseModel
 
 
@@ -52,3 +52,13 @@ class Trade(Position):
         return cls(
             close_date=close_date, close_price=close_price, **position.model_dump()
         )
+
+
+class Portfolio(BaseModel):
+    """A mapping of an account's available coins.
+
+    Attributes:
+        assets: a dictionary where each key is a coin and the associated value is the available amount of that coin
+    """
+
+    assets: dict[Coin, float]

--- a/athena/optimize/orders.py
+++ b/athena/optimize/orders.py
@@ -23,8 +23,8 @@ class Position(BaseModel):
     """
 
     strategy_name: str = ""
-    coin: str
-    currency: str
+    coin: Coin
+    currency: Coin
 
     open_date: datetime.datetime
     open_price: float
@@ -40,8 +40,8 @@ class Position(BaseModel):
     def from_money_to_invest(
         cls,
         strategy_name: str,
-        coin: str,
-        currency: str,
+        coin: Coin,
+        currency: Coin,
         open_date: datetime.datetime,
         open_price: float,
         money_to_invest: float,
@@ -115,3 +115,6 @@ class Portfolio(BaseModel):
     """
 
     assets: dict[Coin, float]
+
+    def get_available(self, coin: Coin) -> float:
+        return self.assets.get(coin, 0)

--- a/athena/optimize/orders.py
+++ b/athena/optimize/orders.py
@@ -125,3 +125,18 @@ class Portfolio(BaseModel):
 
     def get_available(self, coin: Coin) -> float:
         return self.assets.get(coin, 0)
+
+    def update_coin_amount(self, coin: Coin, amount_to_add: float) -> None:
+        """Update coin's available amount in portfolio.
+
+        Args:
+            coin: the coin name to update
+            amount_to_add: the coin's amount to be added, could be negative
+
+        Raises:
+            ValueError: if coin's amount falls below zero
+        """
+        updated_amount = self.get_available(coin) + amount_to_add
+        if updated_amount < 0:
+            raise ValueError(f"Trying to set a negative amount of `{coin}`")
+        self.assets[coin] = updated_amount

--- a/athena/optimize/strategy.py
+++ b/athena/optimize/strategy.py
@@ -44,6 +44,7 @@ class Strategy:
         """
         signals = self.compute_signals(fluctuations=fluctuations)
 
+        # TODO : check for some decorator to check size of compute_signals() ?
         if len(signals) > len(fluctuations):
             raise ValueError(
                 f"The strategy `{self.name}` produced too many signals, expected {len(fluctuations)}, got {len(signals)}"

--- a/athena/optimize/strategy.py
+++ b/athena/optimize/strategy.py
@@ -76,4 +76,4 @@ class Strategy:
 
 
 def split_uppercase_words(string: str) -> list[str]:
-    return re.findall("[A-Z][^A-Z]*", string)
+    return re.sub(r"([A-Z]+)", r" \1", string).split()

--- a/athena/optimize/strategy.py
+++ b/athena/optimize/strategy.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 import pandas as pd
 import datetime
 from athena.types import Signal
@@ -9,8 +11,6 @@ class Strategy:
     position_size: float
     stop_loss_pct: float | None = None
     take_profit_pct: float | None = None
-
-    signals: dict[datetime.datetime, Signal] = {}
 
     def __init__(
         self,
@@ -27,15 +27,16 @@ class Strategy:
         self.position_size = position_size
         self.stop_loss_pct = stop_loss_pct
         self.take_profit_pct = take_profit_pct
-        self.signals = None
 
-    def get_signals(self, fluctuations: pd.DataFrame) -> {datetime.datetime, Signal}:
+    def get_signals(
+        self, fluctuations: pd.DataFrame
+    ) -> Iterable[tuple[datetime.datetime, Signal]]:
         """Get the strategy signals associated to input fluctuations.
 
         Args:
             fluctuations: financial data
 
-        Returns:
+        Yields:
             a mapping of signal for each date as a dictionary
 
         Raises:
@@ -50,13 +51,11 @@ class Strategy:
 
         # fill signals with WAIT at the beginning
         signals = [Signal.WAIT] * (len(fluctuations) - len(signals)) + signals
-        return {
-            date: signal
-            for date, signal in zip(
-                fluctuations["open_time"],
-                signals,
-            )
-        }
+        for date, signal in zip(
+            fluctuations["open_time"],
+            signals,
+        ):
+            yield date, signal
 
     def compute_signals(self, fluctuations: pd.DataFrame) -> list[Signal]:
         """Compute the signals associated to fluctuations based on a strategy.

--- a/athena/types/__init__.py
+++ b/athena/types/__init__.py
@@ -1,5 +1,5 @@
 from athena.types.candle import Candle
 from athena.types.period import Period
-from athena.types.enums import Signal, Side
+from athena.types.enums import Signal, Side, Coin
 
-__all__ = ["Candle", "Period", "Signal", "Side"]
+__all__ = ["Candle", "Period", "Signal", "Side", Coin]

--- a/athena/types/candle.py
+++ b/athena/types/candle.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import pandas as pd
 
 
 class Candle:
@@ -48,6 +49,11 @@ class Candle:
         self.nb_trades = nb_trades
         self.taker_volume = taker_volume
         self.taker_quote_volume = taker_quote_volume
+
+    @classmethod
+    def from_fluctuation(cls, row: pd.Series):
+        """Temporary, wait for collection of candles class."""
+        return cls(**row.to_dict())
 
     def __repr__(self):
         return str(self.__dict__)

--- a/athena/types/enums.py
+++ b/athena/types/enums.py
@@ -2,11 +2,16 @@ import enum
 
 
 class Signal(enum.Enum):
-    BUY: str = "buy"
-    SELL: str = "sell"
-    WAIT: str = "wait"
+    BUY = "buy"
+    SELL = "sell"
+    WAIT = "wait"
 
 
 class Side(enum.Enum):
     LONG = "long"
     SHORT = "short"
+
+
+class Coin(enum.Enum):
+    BTC = "BTC"
+    USDT = "USDT"

--- a/athena/types/period.py
+++ b/athena/types/period.py
@@ -3,6 +3,7 @@ from typing import Literal
 UNITS = {
     "m": "minutes",
     "h": "hours",
+    "d": "days",
 }
 
 

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1,0 +1,45 @@
+import pandas as pd
+
+from athena.optimize import Strategy
+from athena.types import Signal
+
+
+class StrategyBuyMondaySellFriday(Strategy):
+    def compute_signals(self, fluctuations: pd.DataFrame) -> list[Signal]:
+        """Return dummy signals."""
+        signals = []
+        for _, row in fluctuations.iterrows():
+            match row["open_time"].isoweekday():
+                case 6 | 7:  # weekend
+                    signals.append(Signal.WAIT)
+                case 1:  # all-in on monday, typical crypto player
+                    signals.append(Signal.BUY)
+                case 2 | 3 | 4:  # no money left
+                    signals.append(Signal.BUY)
+                case 5:  # panic sell on friday, typical crypto player
+                    signals.append(Signal.SELL)
+        return signals
+
+
+def test_get_trades_from_strategy_and_fluctuations_with_sell_signal():
+    # TODO : use StrategyBuyMondaySellFriday() with sell signal, check the trade == expected_trade
+    #        check also portfolio expected wealth
+    pass
+
+
+def test_get_trades_from_strategy_and_fluctuations_price_reach_tp():
+    # TODO : use StrategyBuyMondaySellFriday() with price reaching take profit, check the trade == expected_trade
+    #        check also portfolio expected wealth
+    pass
+
+
+def test_get_trades_from_strategy_and_fluctuations_price_reach_sl():
+    # TODO : use StrategyBuyMondaySellFriday() with price reaching stop loss, check the trade == expected_trade
+    #        check also portfolio expected wealth
+    pass
+
+
+def test_get_trades_from_strategy_and_fluctuations_position_not_closed():
+    # TODO : use StrategyBuyMondaySellFriday() (stopping before friday) and check no trades are returned
+    #        check also portfolio expected wealth (should be coins + some currency)
+    pass

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -42,7 +42,11 @@ def test_get_trades_from_strategy_and_fluctuations_with_sell_signal():
     fluctuations = pd.DataFrame(
         {
             "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "close_time": pd.date_range("2024-08-20", "2024-08-26", freq="D"),
             "period": "1d",
+            "open": [50, 100, 150, 200, 250, 300, 350],
+            "high": [125, 175, 225, 275, 325, 375, 425],
+            "low": [40, 90, 140, 190, 240, 290, 340],
             "close": [100, 150, 200, 250, 300, 350, 400],
         }
     )
@@ -83,6 +87,7 @@ def test_get_trades_from_strategy_and_fluctuations_price_reach_tp():
     fluctuations = pd.DataFrame(
         {
             "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "close_time": pd.date_range("2024-08-20", "2024-08-26", freq="D"),
             "period": "1d",
             "open": [50, 100, 150, 200, 250, 300, 350],
             "high": [125, 175, 225, 275, 325, 375, 425],
@@ -103,19 +108,19 @@ def test_get_trades_from_strategy_and_fluctuations_price_reach_tp():
             "2024-08-20 00:00:00"
         ),  # open next day = tuesday
         "close_date": datetime.datetime.fromisoformat(
-            "2024-08-24 00:00:00"
+            "2024-08-21 00:00:00"  # "high_time" is missing, so we take close_time
         ),  # close next day = saturday
-        "trade_duration": datetime.timedelta(days=4),
+        "trade_duration": datetime.timedelta(days=1),
         "initial_investment": 33.0,
         "open_price": 100.0,
-        "close_price": 300.0,
+        "close_price": 110.00000000000001,
         "amount": 0.32966999999999996,
         "stop_loss": None,
         "take_profit": 110.00000000000001,
         "open_fees": 0.033,
-        "close_fees": 0.09890099999999999,
-        "total_fees": 0.131901,
-        "total_profit": 65.76909899999998,
+        "close_fees": 0.0362637,
+        "total_fees": 0.06926370000000001,
+        "total_profit": 3.1944363,
         "is_win": True,
         "side": Side.LONG,
     }
@@ -127,6 +132,7 @@ def test_get_trades_from_strategy_and_fluctuations_price_reach_sl():
     fluctuations = pd.DataFrame(
         {
             "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "close_time": pd.date_range("2024-08-20", "2024-08-26", freq="D"),
             "period": "1d",
             "open": [50, 100, 150, 200, 250, 300, 350],
             "high": [125, 175, 225, 275, 325, 375, 425],
@@ -171,7 +177,11 @@ def test_get_trades_from_strategy_and_fluctuations_position_not_closed():
     fluctuations = pd.DataFrame(
         {
             "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "close_time": pd.date_range("2024-08-20", "2024-08-26", freq="D"),
             "period": "1d",
+            "open": [50, 100, 150, 200, 250, 300, 350],
+            "high": [125, 175, 225, 275, 325, 375, 425],
+            "low": [40, 90, 140, 190, 240, 290, 340],
             "close": [100, 150, 200, 250, 300, 350, 400],
         }
     )

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -46,7 +46,7 @@ def test_get_trades_from_strategy_and_fluctuations_with_sell_signal():
             "close": [100, 150, 200, 250, 300, 350, 400],
         }
     )
-    trades, open_position = get_trades_from_strategy_and_fluctuations(
+    trades, open_position, _ = get_trades_from_strategy_and_fluctuations(
         strategy=strategy, fluctuations=fluctuations
     )
 
@@ -75,18 +75,95 @@ def test_get_trades_from_strategy_and_fluctuations_with_sell_signal():
         "is_win": True,
         "side": Side.LONG,
     }
+    assert open_position is None
 
 
 def test_get_trades_from_strategy_and_fluctuations_price_reach_tp():
-    # TODO : use StrategyBuyMondaySellFriday() with price reaching take profit, check the trade == expected_trade
-    #        check also portfolio expected wealth
-    pass
+    strategy = StrategyBuyMondaySellFriday(position_size=0.33, take_profit_pct=0.1)
+    fluctuations = pd.DataFrame(
+        {
+            "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "period": "1d",
+            "open": [50, 100, 150, 200, 250, 300, 350],
+            "high": [125, 175, 225, 275, 325, 375, 425],
+            "low": [40, 90, 140, 190, 240, 290, 340],
+            "close": [100, 150, 200, 250, 300, 350, 400],
+        }
+    )
+    trades, open_position, _ = get_trades_from_strategy_and_fluctuations(
+        strategy=strategy, fluctuations=fluctuations
+    )
+
+    assert len(trades) == 1
+    assert trades[0].model_dump() == {
+        "strategy_name": "strategy_buy_monday_sell_friday",
+        "coin": Coin.BTC,
+        "currency": Coin.USDT,
+        "open_date": datetime.datetime.fromisoformat(
+            "2024-08-20 00:00:00"
+        ),  # open next day = tuesday
+        "close_date": datetime.datetime.fromisoformat(
+            "2024-08-24 00:00:00"
+        ),  # close next day = saturday
+        "trade_duration": datetime.timedelta(days=4),
+        "initial_investment": 33.0,
+        "open_price": 100.0,
+        "close_price": 300.0,
+        "amount": 0.32966999999999996,
+        "stop_loss": None,
+        "take_profit": 110.00000000000001,
+        "open_fees": 0.033,
+        "close_fees": 0.09890099999999999,
+        "total_fees": 0.131901,
+        "total_profit": 65.76909899999998,
+        "is_win": True,
+        "side": Side.LONG,
+    }
+    assert open_position is None
 
 
 def test_get_trades_from_strategy_and_fluctuations_price_reach_sl():
-    # TODO : use StrategyBuyMondaySellFriday() with price reaching stop loss, check the trade == expected_trade
-    #        check also portfolio expected wealth
-    pass
+    strategy = StrategyBuyMondaySellFriday(position_size=0.33, stop_loss_pct=0.1)
+    fluctuations = pd.DataFrame(
+        {
+            "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "period": "1d",
+            "open": [50, 100, 150, 200, 250, 300, 350],
+            "high": [125, 175, 225, 275, 325, 375, 425],
+            "low": [40, 90, 140, 190, 240, 290, 340],
+            "close": [100, 150, 200, 250, 300, 350, 400],
+        }
+    )
+    trades, open_position, _ = get_trades_from_strategy_and_fluctuations(
+        strategy=strategy, fluctuations=fluctuations
+    )
+
+    assert len(trades) == 1
+    assert trades[0].model_dump() == {
+        "strategy_name": "strategy_buy_monday_sell_friday",
+        "coin": Coin.BTC,
+        "currency": Coin.USDT,
+        "open_date": datetime.datetime.fromisoformat(
+            "2024-08-20 00:00:00"
+        ),  # open next day = tuesday
+        "close_date": datetime.datetime.fromisoformat(
+            "2024-08-24 00:00:00"
+        ),  # close next day = saturday
+        "trade_duration": datetime.timedelta(days=4),
+        "initial_investment": 33.0,
+        "open_price": 100.0,
+        "close_price": 300.0,
+        "amount": 0.32966999999999996,
+        "stop_loss": 90.0,
+        "take_profit": None,
+        "open_fees": 0.033,
+        "close_fees": 0.09890099999999999,
+        "total_fees": 0.131901,
+        "total_profit": 65.76909899999998,
+        "is_win": True,
+        "side": Side.LONG,
+    }
+    assert open_position is None
 
 
 def test_get_trades_from_strategy_and_fluctuations_position_not_closed():
@@ -98,7 +175,7 @@ def test_get_trades_from_strategy_and_fluctuations_position_not_closed():
             "close": [100, 150, 200, 250, 300, 350, 400],
         }
     )
-    trades, open_position = get_trades_from_strategy_and_fluctuations(
+    trades, open_position, _ = get_trades_from_strategy_and_fluctuations(
         strategy=strategy, fluctuations=fluctuations
     )
     assert trades == []

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -24,10 +24,57 @@ class StrategyBuyMondaySellFriday(Strategy):
         return signals
 
 
+class StrategyMondayDCA(Strategy):
+    def compute_signals(self, fluctuations: pd.DataFrame) -> list[Signal]:
+        """Return dummy signals."""
+        signals = []
+        for _, row in fluctuations.iterrows():
+            match row["open_time"].isoweekday():
+                case 1:  # dca on monday
+                    signals.append(Signal.BUY)
+                case _:
+                    signals.append(Signal.WAIT)
+        return signals
+
+
 def test_get_trades_from_strategy_and_fluctuations_with_sell_signal():
-    # TODO : use StrategyBuyMondaySellFriday() with sell signal, check the trade == expected_trade
-    #        check also portfolio expected wealth
-    pass
+    strategy = StrategyBuyMondaySellFriday(position_size=0.33)
+    fluctuations = pd.DataFrame(
+        {
+            "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "period": "1d",
+            "close": [100, 150, 200, 250, 300, 350, 400],
+        }
+    )
+    trades, open_position = get_trades_from_strategy_and_fluctuations(
+        strategy=strategy, fluctuations=fluctuations
+    )
+
+    assert len(trades) == 1
+    assert trades[0].model_dump() == {
+        "strategy_name": "strategy_buy_monday_sell_friday",
+        "coin": Coin.BTC,
+        "currency": Coin.USDT,
+        "open_date": datetime.datetime.fromisoformat(
+            "2024-08-20 00:00:00"
+        ),  # open next day = tuesday
+        "close_date": datetime.datetime.fromisoformat(
+            "2024-08-24 00:00:00"
+        ),  # close next day = saturday
+        "trade_duration": datetime.timedelta(days=4),
+        "initial_investment": 33.0,
+        "open_price": 100.0,
+        "close_price": 300.0,
+        "amount": 0.32966999999999996,
+        "stop_loss": None,
+        "take_profit": None,
+        "open_fees": 0.033,
+        "close_fees": 0.09890099999999999,
+        "total_fees": 0.131901,
+        "total_profit": 65.76909899999998,
+        "is_win": True,
+        "side": Side.LONG,
+    }
 
 
 def test_get_trades_from_strategy_and_fluctuations_price_reach_tp():
@@ -43,10 +90,11 @@ def test_get_trades_from_strategy_and_fluctuations_price_reach_sl():
 
 
 def test_get_trades_from_strategy_and_fluctuations_position_not_closed():
-    strategy = StrategyBuyMondaySellFriday(position_size=0.33)
+    strategy = StrategyMondayDCA(position_size=0.33)
     fluctuations = pd.DataFrame(
         {
             "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "period": "1d",
             "close": [100, 150, 200, 250, 300, 350, 400],
         }
     )
@@ -55,10 +103,12 @@ def test_get_trades_from_strategy_and_fluctuations_position_not_closed():
     )
     assert trades == []
     assert open_position.model_dump() == {
-        "strategy_name": "strategy_buy_monday_sell_friday",
+        "strategy_name": "strategy_monday_dca",
         "coin": Coin.BTC,
         "currency": Coin.USDT,
-        "open_date": datetime.datetime.fromisoformat("2024-08-19 00:00:00"),
+        "open_date": datetime.datetime.fromisoformat(
+            "2024-08-20 00:00:00"
+        ),  # open next day = tuesday
         "initial_investment": 33.0,
         "open_price": 100.0,
         "open_fees": 0.033,

--- a/tests/optimize/test_backtesting.py
+++ b/tests/optimize/test_backtesting.py
@@ -1,7 +1,10 @@
 import pandas as pd
 
+import datetime
+
 from athena.optimize import Strategy
-from athena.types import Signal
+from athena.types import Signal, Coin, Side
+from athena.optimize.backtesting import get_trades_from_strategy_and_fluctuations
 
 
 class StrategyBuyMondaySellFriday(Strategy):
@@ -15,7 +18,7 @@ class StrategyBuyMondaySellFriday(Strategy):
                 case 1:  # all-in on monday, typical crypto player
                     signals.append(Signal.BUY)
                 case 2 | 3 | 4:  # no money left
-                    signals.append(Signal.BUY)
+                    signals.append(Signal.WAIT)
                 case 5:  # panic sell on friday, typical crypto player
                     signals.append(Signal.SELL)
         return signals
@@ -40,6 +43,27 @@ def test_get_trades_from_strategy_and_fluctuations_price_reach_sl():
 
 
 def test_get_trades_from_strategy_and_fluctuations_position_not_closed():
-    # TODO : use StrategyBuyMondaySellFriday() (stopping before friday) and check no trades are returned
-    #        check also portfolio expected wealth (should be coins + some currency)
-    pass
+    strategy = StrategyBuyMondaySellFriday(position_size=0.33)
+    fluctuations = pd.DataFrame(
+        {
+            "open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D"),
+            "close": [100, 150, 200, 250, 300, 350, 400],
+        }
+    )
+    trades, open_position = get_trades_from_strategy_and_fluctuations(
+        strategy=strategy, fluctuations=fluctuations
+    )
+    assert trades == []
+    assert open_position.model_dump() == {
+        "strategy_name": "strategy_buy_monday_sell_friday",
+        "coin": Coin.BTC,
+        "currency": Coin.USDT,
+        "open_date": datetime.datetime.fromisoformat("2024-08-19 00:00:00"),
+        "initial_investment": 33.0,
+        "open_price": 100.0,
+        "open_fees": 0.033,
+        "amount": 0.32966999999999996,
+        "side": Side.LONG,
+        "stop_loss": None,
+        "take_profit": None,
+    }

--- a/tests/optimize/test_strategy.py
+++ b/tests/optimize/test_strategy.py
@@ -36,8 +36,8 @@ def test_strategy_get_signals():
         {"open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D")}
     )
     strategy = DummyStrategy()
-    assert strategy.get_signals(fluctuations=fluctuations) == {
-        date: signal
+    assert list(strategy.get_signals(fluctuations=fluctuations)) == [
+        (date, signal)
         for date, signal in zip(
             fluctuations["open_time"],
             [
@@ -50,7 +50,7 @@ def test_strategy_get_signals():
                 Signal.WAIT,
             ],
         )
-    }
+    ]
 
 
 def test_strategy_compute_signals():

--- a/tests/optimize/test_strategy.py
+++ b/tests/optimize/test_strategy.py
@@ -3,8 +3,12 @@ import pandas as pd
 from athena.optimize import Strategy
 from athena.types import Signal
 
+import pytest
 
-class DummyStrategy(Strategy):
+
+class StrategyBuyWeekSellFriday(Strategy):
+    """"""
+
     def compute_signals(self, fluctuations: pd.DataFrame) -> list[Signal]:
         """Return dummy signals."""
         signals = []
@@ -19,23 +23,37 @@ class DummyStrategy(Strategy):
         return signals
 
 
-def test_strategy_params():
-    strategy = DummyStrategy(
+class InvalidStrategy(Strategy):
+    """This strategy returns too many signals."""
+
+    def compute_signals(self, fluctuations: pd.DataFrame) -> list[Signal]:
+        """Return dummy signals."""
+        signals = []
+        for _, row in fluctuations.iterrows():
+            match row["open_time"].isoweekday():
+                case 6 | 7:  # weekend
+                    signals.append(Signal.WAIT)
+                case 1 | 2 | 3 | 4:  # buy from monday to thursday
+                    signals.append(Signal.BUY)
+                case 5:  # panic sell on friday
+                    signals.append(Signal.SELL)
+        return signals + [Signal.WAIT]
+
+
+def test_strategy_name():
+    strategy = StrategyBuyWeekSellFriday(
         position_size=0.33,
         take_profit_pct=0.01,
         stop_loss_pct=0.01,
     )
-    assert strategy.name == "dummy_strategy"
-    assert strategy.position_size == 0.33
-    assert strategy.take_profit_pct == 0.01
-    assert strategy.stop_loss_pct == 0.01
+    assert strategy.name == "strategy_buy_week_sell_friday"
 
 
 def test_strategy_get_signals():
     fluctuations = pd.DataFrame(
         {"open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D")}
     )
-    strategy = DummyStrategy()
+    strategy = StrategyBuyWeekSellFriday()
     assert list(strategy.get_signals(fluctuations=fluctuations)) == [
         (date, signal)
         for date, signal in zip(
@@ -53,11 +71,21 @@ def test_strategy_get_signals():
     ]
 
 
+def test_strategy_get_signals_raises():
+    fluctuations = pd.DataFrame(
+        {"open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D")}
+    )
+    strategy = InvalidStrategy()
+
+    with pytest.raises(ValueError):
+        list(strategy.get_signals(fluctuations=fluctuations))
+
+
 def test_strategy_compute_signals():
     fluctuations = pd.DataFrame(
         {"open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D")}
     )
-    strategy = DummyStrategy()
+    strategy = StrategyBuyWeekSellFriday()
     assert strategy.compute_signals(fluctuations=fluctuations) == [
         Signal.BUY,
         Signal.BUY,

--- a/tests/optimize/test_strategy.py
+++ b/tests/optimize/test_strategy.py
@@ -19,9 +19,8 @@ class DummyStrategy(Strategy):
         return signals
 
 
-def test_strategy_params(sample_fluctuations):
+def test_strategy_params():
     strategy = DummyStrategy(
-        fluctuations=sample_fluctuations(),
         position_size=0.33,
         take_profit_pct=0.01,
         stop_loss_pct=0.01,
@@ -32,12 +31,12 @@ def test_strategy_params(sample_fluctuations):
     assert strategy.stop_loss_pct == 0.01
 
 
-def test_strategy_compute_signals():
+def test_strategy_get_signals():
     fluctuations = pd.DataFrame(
         {"open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D")}
     )
-    strategy = DummyStrategy(fluctuations)
-    assert strategy.signals == {
+    strategy = DummyStrategy()
+    assert strategy.get_signals(fluctuations=fluctuations) == {
         date: signal
         for date, signal in zip(
             fluctuations["open_time"],
@@ -52,3 +51,19 @@ def test_strategy_compute_signals():
             ],
         )
     }
+
+
+def test_strategy_compute_signals():
+    fluctuations = pd.DataFrame(
+        {"open_time": pd.date_range("2024-08-19", "2024-08-25", freq="D")}
+    )
+    strategy = DummyStrategy()
+    assert strategy.compute_signals(fluctuations=fluctuations) == [
+        Signal.BUY,
+        Signal.BUY,
+        Signal.BUY,
+        Signal.BUY,
+        Signal.SELL,
+        Signal.WAIT,
+        Signal.WAIT,
+    ]


### PR DESCRIPTION
## Description

Backtesting module enables strategy performance evaluation based on financial data.

We first compute the trades with
- wait for the strategy to emit an entry signal
- open a position at candle close price (equivalent to next candle's open price)
- wait for an exit condition (price reaches take_profit or stop_loss or limit date)
- transform the position to a completed trade

Performances are a collection of metrics computed from closed trades (later)
- {insert here some fancy metrics}
