### PR TITLE
:tada: download entrypoint update strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Hand-crafted library to create, analyze and deploy your trading strategies.
 
 ## Installation
 
+:warning:
+To use the deep-learning part of this project,
+you need cuda 12.2 to be installed on your machine with recommended nvidia-535 drivers.
+
 Install ```pyenv``` with python ```3.10.12```.
 
 Create your own environment with :
@@ -21,9 +25,22 @@ The project will then automatically configure itself with :
 make setup
 ```
 
+You can either
+
+1. run your code using poetry with `poetry run script.py`
+2. enter the dev container with `make build && make local` to run your code safely.
+
 ## Usage
 
-> [!WARNING]
-> You need cuda 12.2 to be installed on your machine with recommended nvidia-535 drivers
+### download
 
-Build the docker image using ```make build``` and then run it locally with ```make local```.
+
+```bash
+poetry run athena download \
+    --coin btc \
+    --currency usdt \
+    --from-date 2020-01-01 \
+    --to-date 2020-01-15 \
+    --output-dir /data/athena \
+    --overwrite
+```

--- a/athena/entrypoints/cli.py
+++ b/athena/entrypoints/cli.py
@@ -38,6 +38,12 @@ def app():
     type=Path,
     help="Directory to save downloaded candles.",
 )
+@click.option(
+    "--overwrite",
+    default=False,
+    is_flag=True,
+    help="Remove existing candles if set.",
+)
 def download(
     coin: str,
     currency: str,
@@ -45,14 +51,16 @@ def download(
     to_date: str,
     timeframe: str,
     output_dir: Path,
+    overwrite: bool,
 ):
     download_daily_market_candles(
-        coin=coin,
-        currency=currency,
+        coin=coin.upper(),
+        currency=currency.upper(),
         from_date=from_date,
         to_date=to_date,
         timeframe=timeframe,
         output_dir=output_dir,
+        overwrite=overwrite,
     )
 
 


### PR DESCRIPTION
# Description

The download entrypoint now look for available candles to avoid downloading them again.

You can pass a new `--overwrite` parameter to CLI to overwrite local data.