### PR TITLE
:tada: Getter for Candle's available attributes

### DIFF
--- a/athena/core/interfaces/candle.py
+++ b/athena/core/interfaces/candle.py
@@ -59,5 +59,5 @@ class Candle(BaseModel):
         return self.model_dump() == other.model_dump()
 
     @classmethod
-    def is_public_attribute(cls, attr: str) -> bool:
+    def is_available_attribute(cls, attr: str) -> bool:
         return attr in AVAILABLE_ATTRIBUTES

--- a/athena/core/interfaces/candle.py
+++ b/athena/core/interfaces/candle.py
@@ -3,6 +3,23 @@ import datetime
 from pydantic import BaseModel
 
 
+AVAILABLE_ATTRIBUTES = (
+    "open",
+    "high",
+    "low",
+    "close",
+    "open_time",
+    "high_time",
+    "low_time",
+    "close_time",
+    "volume",
+    "quote_volume",
+    "nb_trades",
+    "taker_volume",
+    "taker_quote_volume",
+)
+
+
 class Candle(BaseModel):
     """Indicators of a specific candle.
 
@@ -38,8 +55,9 @@ class Candle(BaseModel):
     taker_volume: float
     taker_quote_volume: float
 
-    def __repr__(self):
-        return str(self.__dict__)
-
     def __eq__(self, other):
         return self.model_dump() == other.model_dump()
+
+    @classmethod
+    def is_public_attribute(cls, attr: str) -> bool:
+        return attr in AVAILABLE_ATTRIBUTES

--- a/athena/core/interfaces/fluctuations.py
+++ b/athena/core/interfaces/fluctuations.py
@@ -83,7 +83,7 @@ class Fluctuations(BaseModel):
 
     def get_series(self, attribute_name: str) -> np.ndarray:
         """Get the time series of attribute `name` from candles."""
-        if not Candle.is_public_attribute(attribute_name):
+        if not Candle.is_available_attribute(attribute_name):
             raise ValueError("Trying to access unavailable attribute.")
         return np.array([getattr(candle, attribute_name) for candle in self.candles])
 

--- a/athena/core/interfaces/fluctuations.py
+++ b/athena/core/interfaces/fluctuations.py
@@ -1,5 +1,7 @@
 import datetime
 from functools import cached_property
+
+import numpy as np
 from pydantic import BaseModel, model_validator
 from athena.core.interfaces import Candle
 from athena.core.types import Coin, Period
@@ -78,6 +80,12 @@ class Fluctuations(BaseModel):
 
     def get_candle(self, open_time: datetime.datetime) -> Candle:
         return self.candles[self.candles_mapping.get(open_time)]
+
+    def get_series(self, attribute_name: str) -> np.ndarray:
+        """Get the time series of attribute `name` from candles."""
+        if not Candle.is_public_attribute(attribute_name):
+            raise ValueError("Trying to access unavailable attribute.")
+        return np.array([getattr(candle, attribute_name) for candle in self.candles])
 
     def save(self, path: Path) -> None:
         """Save fluctuations to disk.

--- a/tests/types/interfaces/test_fluctuations_interface.py
+++ b/tests/types/interfaces/test_fluctuations_interface.py
@@ -6,6 +6,7 @@ from athena.core.interfaces import Fluctuations
 from athena.core.types import Period, Coin
 
 from pandas.testing import assert_frame_equal
+import numpy as np
 
 
 def test_fluctuations_from_candles(sample_candles):
@@ -121,3 +122,18 @@ def test_load_fluctuations_convert_period(tmp_path, sample_candles, generate_can
 
     fluctuations = Fluctuations.load(tmp_path, target_period=Period(timeframe="4h"))
     assert len(fluctuations.candles) == 2
+
+
+def test_load_fluctuations_get_series(tmp_path, sample_candles, generate_candles):
+    from_date = datetime.datetime(2020, 1, 1)
+    to_date = datetime.datetime(2020, 1, 1, hour=8)
+    candles = generate_candles(timeframe="1m", from_date=from_date, to_date=to_date)
+
+    fluctuations = Fluctuations.from_candles(candles=candles)
+
+    assert np.allclose(
+        fluctuations.get_series("open"), np.array([candle.open for candle in candles])
+    )
+
+    with pytest.raises(ValueError, match="Trying to access unavailable attribute"):
+        fluctuations.get_series("this_attribute_does_not_exist")


### PR DESCRIPTION
# Description

To run a strategy, we will need to access some values from fluctuations' candles.
We want a concise but clear (and clean) way of doing it, also we don't want the user to access every attribute.
