### PR TITLE
:recycle: Fluctuations load and merge dynamically

### DIFF
--- a/tests/types/interfaces/test_fluctuations_functions.py
+++ b/tests/types/interfaces/test_fluctuations_functions.py
@@ -34,8 +34,7 @@ def test_convert_candles_to_same_period(generate_candles):
 
     merged_candles = convert_candles_to_period(candles, target_period)
 
-    # FIXME : converting from 1m to 1m, last candle is not taken, so add -1
-    assert len(merged_candles) == len(candles) - 1
+    assert len(merged_candles) == len(candles)
 
 
 def test_convert_candles_to_period(generate_candles):


### PR DESCRIPTION
# Description

Previously, we were loading the entire dataste before converting it to the desired period.
Now we convert each file at the time, it saves memory, time, and hair drop.

Also fixed a bug me,tioned in `TODO`