### PR TITLE
:bug: fixed timezone bug in download entrypoint

### DIFF
--- a/athena/hub/client.py
+++ b/athena/hub/client.py
@@ -31,8 +31,8 @@ class BinanceClient:
         self,
         symbol: str,
         interval: str,
-        start_str: str,
-        end_str: str,
+        start_str: str | int,
+        end_str: str | int,
     ):
         """Get historical klines."""
         return self._client.get_historical_klines(

--- a/athena/hub/fetch.py
+++ b/athena/hub/fetch.py
@@ -19,8 +19,8 @@ def fetch_historical_data(
     coin: str,
     currency: str,
     period: Period,
-    start_date: str,
-    end_date: str,
+    start_date: datetime.datetime,
+    end_date: datetime.datetime,
 ) -> Fluctuations:
     """Get candles data between two dates.
 
@@ -54,8 +54,10 @@ def fetch_historical_data(
     bars = client.get_historical_klines(
         symbol=coin + currency,
         interval=period.timeframe,
-        start_str=start_date,
-        end_str=end_date,
+        start_str=int(
+            start_date.timestamp() * 1_000
+        ),  # .strftime("%Y-%m-%d %H:%M:%S"),
+        end_str=int(end_date.timestamp() * 1_000),  # .strftime("%Y-%m-%d %H:%M:%S"),
     )
     candles = []
     for bar in bars:
@@ -144,10 +146,8 @@ def download_daily_market_candles(
             coin=coin,
             currency=currency,
             period=period,
-            start_date=start_date.strftime("%Y-%m-%d %H:%M:%S"),
-            end_date=(start_date + datetime.timedelta(days=1)).strftime(
-                "%Y-%m-%d %H:%M:%S"
-            ),
+            start_date=start_date,
+            end_date=start_date + datetime.timedelta(days=1),
         )
 
         if not fluctuations.candles:

--- a/tests/hub/test_fetch.py
+++ b/tests/hub/test_fetch.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from athena.hub.fetch import fetch_historical_data
 from athena.hub.client import (
     BinanceClient,
@@ -38,8 +40,8 @@ def test_fetch_historical_data(mocker, sample_bars, sample_candles):
             coin="BTC",
             currency="USDT",
             period=period,
-            start_date="2020-01-01",
-            end_date="2020-01-02",
+            start_date=datetime.strptime("2020-01-01", "%Y-%m-%d"),
+            end_date=datetime.strptime("2020-01-02", "%Y-%m-%d"),
         ).model_dump()
         == Fluctuations.from_candles(candles).model_dump()
     )


### PR DESCRIPTION
# Description

Solved a bug that fetched data from 1 a.m. to 1 a.m. next day. Date given to binance was in UTM+1 zone, now is a timestampt in milliseconds from programming historical starting date.
Also definitely (:crossed_fingers: ) fixed the last candle bug in convert candles period.
