### PR TITLE
:bug: Fix backtesting portfolio update

### DIFF
--- a/athena/tradingtools/backtesting.py
+++ b/athena/tradingtools/backtesting.py
@@ -36,6 +36,13 @@ def get_trades_from_strategy_and_fluctuations(
                 close_price=close_price,
             )
             trades.append(position)
+            portfolio.update_coin_amount(
+                coin=currency,
+                amount_to_add=position.initial_investment + position.total_profit,
+            )
+            portfolio.update_coin_amount(
+                coin=traded_coin, amount_to_add=-position.amount
+            )
             position = None
 
         if signal == Signal.BUY and position is None:

--- a/tests/tradingtools/test_backtesting.py
+++ b/tests/tradingtools/test_backtesting.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 from athena.core.interfaces import Fluctuations
-from athena.tradingtools import Strategy
+from athena.tradingtools import Strategy, Portfolio
 from athena.core.types import Signal, Coin, Side
 from athena.tradingtools.backtesting import (
     get_trades_from_strategy_and_fluctuations,
@@ -79,7 +79,7 @@ def test_get_trades_from_strategy_and_fluctuations_with_sell_signal(fluctuations
 
 def test_get_trades_from_strategy_and_fluctuations_price_reach_tp(fluctuations):
     strategy = StrategyBuyMondaySellFriday(position_size=0.33, take_profit_pct=0.1)
-    trades, _ = get_trades_from_strategy_and_fluctuations(
+    trades, portfolio = get_trades_from_strategy_and_fluctuations(
         strategy=strategy,
         fluctuations=fluctuations(
             timeframe="1d", include_high_time=False, include_low_time=False
@@ -112,6 +112,13 @@ def test_get_trades_from_strategy_and_fluctuations_price_reach_tp(fluctuations):
         "is_win": True,
         "side": Side.LONG,
     }
+    assert (
+        portfolio.get_available(Coin.USDT)
+        == Portfolio.model_validate({"assets": {Coin.USDT: 100}}).get_available(
+            Coin.USDT
+        )
+        + trades[0].total_profit
+    )
 
 
 def test_get_trades_from_strategy_and_fluctuations_price_reach_sl(fluctuations):


### PR DESCRIPTION
# Description

When price reaches TP or SL, the position was closed but the potfolio wasn't updated.
Fixed now.