### PR TITLE
:tada: New backtest entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ poetry run athena download \
     --output-dir /data/athena/market_data \
     --overwrite
 ```
+
+
+### backtest
+
+
+```bash
+poetry run athena backtest \
+    --config-path /path/to/my_config.yaml \
+    --root-dir /path/to/raw_market_data \
+    --output-dir /path/to/results
+```

--- a/athena/core/context.py
+++ b/athena/core/context.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import os
 
+DATA_DIR = Path("/data/athena")
+
 
 class ProjectContext:
     def __init__(self, root_dir: Path | None = None):
@@ -19,3 +21,7 @@ class ProjectContext:
     @property
     def credentials_file(self) -> Path:
         return self._root_dir / ".credentials"
+
+    @property
+    def raw_data_directory(self) -> Path:
+        return DATA_DIR / "raw_market_data"

--- a/athena/entrypoints/cli.py
+++ b/athena/entrypoints/cli.py
@@ -1,4 +1,6 @@
+from athena.core.context import ProjectContext
 from athena.hub.fetch import download_daily_market_candles
+from athena.tradingtools.backtesting import backtest as backtest_main, BacktestConfig
 from pathlib import Path
 import datetime
 
@@ -61,6 +63,40 @@ def download(
         timeframe=timeframe,
         output_dir=output_dir,
         overwrite=overwrite,
+    )
+
+
+@app.command()
+@click.option(
+    "--config-path",
+    "-c",
+    required=True,
+    type=Path,
+    help="Path to the backtesting configuration file.",
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    required=True,
+    type=Path,
+    help="Directory to save backtesting results.",
+)
+@click.option(
+    "--root-dir",
+    "-r",
+    default=ProjectContext().raw_data_directory,
+    type=Path,
+    help="Location of raw market data.",
+)
+def backtest(
+    config_path: Path,
+    output_dir: Path,
+    root_dir: Path,
+):
+    backtest_main(
+        config=BacktestConfig.model_validate_json(config_path.read_text()),
+        output_dir=output_dir,
+        root_dir=root_dir,
     )
 
 

--- a/athena/tradingtools/strategies/__init__.py
+++ b/athena/tradingtools/strategies/__init__.py
@@ -5,6 +5,6 @@ from athena.tradingtools.strategies.dca import StrategyDCA
 STRATEGIES_MATCH = {"strategy_dca": StrategyDCA}
 
 
-def get_strategy(strategy_name: str, strategy_params: dict[str:Any]):
+def init_strategy(strategy_name: str, strategy_params: dict[str:Any]):
     """Build a Strategy object."""
     return STRATEGIES_MATCH[strategy_name](**strategy_params)

--- a/athena/tradingtools/strategies/__init__.py
+++ b/athena/tradingtools/strategies/__init__.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+from athena.tradingtools.strategies.dca import StrategyDCA
+
+STRATEGIES_MATCH = {"strategy_dca": StrategyDCA}
+
+
+def get_strategy(strategy_name: str, strategy_params: dict[str:Any]):
+    """Build a Strategy object."""
+    return STRATEGIES_MATCH[strategy_name](**strategy_params)

--- a/tests/entrypoints/test_backtest.py
+++ b/tests/entrypoints/test_backtest.py
@@ -1,0 +1,64 @@
+import datetime
+import json
+
+from click.testing import CliRunner
+import pytest
+
+from athena.core.interfaces import Fluctuations
+
+from athena.entrypoints.cli import app
+
+
+@pytest.fixture
+def config():
+    return {
+        "data": {
+            "coin": "BTC",
+            "currency": "USDT",
+            "period": "1h",
+            "from_date": "2020-01-01",
+            "to_date": "2021-01-01",
+        },
+        "strategy": {
+            "name": "strategy_dca",
+            "parameters": {
+                "weekday": "every_day",
+                "hour": 12,
+                "stop_loss_pct": 0.01,
+                "take_profit_pct": 0.01,
+                "position_size": 0.01,
+            },
+        },
+    }
+
+
+def test_run_backtest(config, generate_candles, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    root_dir = tmp_path / "raw_market_data"
+    output_dir = tmp_path / "results"
+
+    config_path.write_text(json.dumps(config))
+    Fluctuations.from_candles(
+        generate_candles(
+            from_date=datetime.datetime(2020, 1, 1),
+            to_date=datetime.datetime(2020, 1, 3),
+            timeframe="1m",
+        )
+    ).save(root_dir / "BTC_USDT_1m")
+
+    runner = CliRunner().invoke(
+        app,
+        [
+            "backtest",
+            "--config-path",
+            config_path.as_posix(),
+            "--root-dir",
+            root_dir.as_posix(),
+            "--output-dir",
+            output_dir.as_posix(),
+        ],
+    )
+
+    assert runner.exit_code == 0
+
+    assert (output_dir / "performance_report.html").exists()


### PR DESCRIPTION
# Description

Adding `backtest` command to athena.
Run a backtest using a YAML configuration file, see example:
```yaml
data:
    coin: "BTC"
    currency: "USDT"
    period: "1h"
    from_date: "2020-01-01"
    to_date: "2021-01-01"
strategy:
    name: "strategy_dca"
    parameters:
        weekday: "every_day"
        hour: 12
        stop_loss_pct: 0.01
        take_profit_pct: 0.01
        position_size: 0.01
```

# Example

```bash
poetry run athena backtest \
    --config-path /path/to/my_config.yaml \
    --root-dir /path/to/raw_market_data \
    --output-dir /path/to/results
```

that