### PR TITLE
:recycle: switch `Candle` from `BaseModel` to `dataclass`

### DIFF
--- a/athena/core/interfaces/candle.py
+++ b/athena/core/interfaces/candle.py
@@ -1,6 +1,8 @@
 import datetime
 
-from pydantic import BaseModel
+from dataclasses import dataclass, asdict
+
+import pandas as pd
 
 AVAILABLE_ATTRIBUTES = (
     "open",
@@ -19,7 +21,8 @@ AVAILABLE_ATTRIBUTES = (
 )
 
 
-class Candle(BaseModel):
+@dataclass
+class Candle:
     """Indicators of a specific candle.
 
     coin: the base coin
@@ -41,8 +44,7 @@ class Candle(BaseModel):
     currency: str
     period: str
     open_time: datetime.datetime
-    high_time: datetime.datetime | None = None
-    low_time: datetime.datetime | None = None
+
     close_time: datetime.datetime
     open: float
     high: float
@@ -54,9 +56,18 @@ class Candle(BaseModel):
     taker_volume: float
     taker_quote_volume: float
 
+    high_time: datetime.datetime | None = None
+    low_time: datetime.datetime | None = None
+
     def __eq__(self, other):
-        return self.model_dump() == other.model_dump()
+        return asdict(self) == asdict(other)
 
     @classmethod
     def is_available_attribute(cls, attr: str) -> bool:
         return attr in AVAILABLE_ATTRIBUTES
+
+    def to_dataframe(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {attribute: str(value) for attribute, value in asdict(self).items()},
+            index=[0],
+        )

--- a/athena/core/interfaces/candle.py
+++ b/athena/core/interfaces/candle.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, asdict
 
 import pandas as pd
 
+from athena.core.types import Coin, Period
+
 AVAILABLE_ATTRIBUTES = (
     "open",
     "high",
@@ -40,9 +42,9 @@ class Candle:
     taker_quote_volume: the volume of currency earned by selling orders that have been filled
     """
 
-    coin: str
-    currency: str
-    period: str
+    coin: Coin
+    currency: Coin
+    period: Period
     open_time: datetime.datetime
 
     close_time: datetime.datetime

--- a/athena/core/interfaces/fluctuations.py
+++ b/athena/core/interfaces/fluctuations.py
@@ -115,9 +115,7 @@ class Fluctuations(BaseModel):
             return
 
         path.parent.mkdir(parents=True, exist_ok=True)
-        df = pd.concat(
-            [pd.DataFrame(candle.model_dump(), index=[0]) for candle in self.candles]
-        )
+        df = pd.concat([candle.to_dataframe() for candle in self.candles])
         df.to_csv(path.as_posix(), index=False)
 
     @classmethod
@@ -190,7 +188,7 @@ def load_candles_from_file(
             }
         )
     )
-    candles = [Candle.model_validate(row.to_dict()) for _, row in df.iterrows()]
+    candles = [Candle(**row.to_dict()) for _, row in df.iterrows()]
     if target_period is not None:
         candles = _convert_candles_to_period(candles, target_period=target_period)
     return candles

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,29 +244,27 @@ def fluctuations():
         period = Period(timeframe=timeframe)
         return Fluctuations.from_candles(
             candles=[
-                Candle.model_validate(
-                    {
-                        "coin": coin,
-                        "currency": currency,
-                        "open_time": open_time,
-                        "period": period.timeframe,
-                        "close_time": open_time + period.to_timedelta(),
-                        "high_time": (open_time + datetime.timedelta(hours=12))
-                        if include_high_time
-                        else None,
-                        "low_time": (open_time + datetime.timedelta(hours=3))
-                        if include_low_time
-                        else None,
-                        "open": open,
-                        "high": high,
-                        "low": low,
-                        "close": close,
-                        "volume": 100,
-                        "quote_volume": (open + high) / 2 * 100,
-                        "nb_trades": 100,
-                        "taker_volume": 50,
-                        "taker_quote_volume": (open + high) / 2 * 100 / 2,
-                    }
+                Candle(
+                    coin=coin,
+                    currency=currency,
+                    open_time=open_time,
+                    period=period.timeframe,
+                    close_time=open_time + period.to_timedelta(),
+                    high_time=(open_time + datetime.timedelta(hours=12))
+                    if include_high_time
+                    else None,
+                    low_time=(open_time + datetime.timedelta(hours=3))
+                    if include_low_time
+                    else None,
+                    open=open,
+                    high=high,
+                    low=low,
+                    close=close,
+                    volume=100,
+                    quote_volume=(open + high) / 2 * 100,
+                    nb_trades=100,
+                    taker_volume=50,
+                    taker_quote_volume=(open + high) / 2 * 100 / 2,
                 )
                 for open_time, open, high, low, close in zip(
                     [

--- a/tests/core/interfaces/test_fluctuations_interface.py
+++ b/tests/core/interfaces/test_fluctuations_interface.py
@@ -109,15 +109,17 @@ def test_fluctuations_save_to_file(tmp_path, sample_candles, sample_fluctuations
         tmp_path / "fluctuations.csv"
     )
     assert_frame_equal(
-        pd.read_csv(tmp_path / "fluctuations.csv").astype(
+        pd.read_csv(tmp_path / "fluctuations.csv")
+        .astype(
             {
                 "open_time": "datetime64[ns]",
                 "high_time": "datetime64[ns]",
                 "low_time": "datetime64[ns]",
                 "close_time": "datetime64[ns]",
             }
-        ),
-        sample_fluctuations(),
+        )
+        .sort_index(axis=1),
+        sample_fluctuations().sort_index(axis=1),
     )
 
 

--- a/tests/core/test_market_entities.py
+++ b/tests/core/test_market_entities.py
@@ -18,23 +18,21 @@ def position():
 
 @pytest.fixture
 def candle():
-    return Candle.model_validate(
-        {
-            "coin": Coin.default_coin(),
-            "currency": Coin.default_currency(),
-            "period": "1h",
-            "open_time": datetime.datetime(2024, 8, 25),
-            "close_time": datetime.datetime(2024, 8, 26),
-            "open": 130,
-            "high": 140,
-            "low": 120,
-            "close": 130,
-            "volume": 100,
-            "quote_volume": 140,
-            "nb_trades": 100,
-            "taker_volume": 50,
-            "taker_quote_volume": 70,
-        }
+    return Candle(
+        coin=Coin.default_coin(),
+        currency=Coin.default_currency(),
+        period="1h",
+        open_time=datetime.datetime(2024, 8, 25),
+        close_time=datetime.datetime(2024, 8, 26),
+        open=130,
+        high=140,
+        low=0,
+        close=130,
+        volume=100,
+        quote_volume=140,
+        nb_trades=100,
+        taker_volume=50,
+        taker_quote_volume=70,
     )
 
 
@@ -65,6 +63,7 @@ def test_get_exit_signal_take_profit(position, candle):
 
     candle.high = 151
     candle.high_time = datetime.datetime(2024, 8, 25, hour=12)
+    candle.low_time = datetime.datetime(2024, 8, 25, hour=13)
 
     exit_signal = position.get_exit_signal(candle=candle)
 


### PR DESCRIPTION
# Description

BaseModel takes some time to instantiate so it's more suitable for models rather data instances.

* `Candles` is a `dataclass` instead inheriting from `BaseModel`
* fixed a test where candle missed an attribute
* x2 test speed !